### PR TITLE
ダイスボット一覧をBCDice-APIの出力順のまま表示する

### DIFF
--- a/src/dice.ts
+++ b/src/dice.ts
@@ -36,17 +36,9 @@ export function getBcdiceURL(): string {
 
 export async function fetchDicebots(): Promise<DiceName[]> {
   const res = await axios.get(apiNames);
-  return res.data.names
-    .map((x: NameRes) => {
-      return { gameType: x.system, name: x.name };
-    })
-    .sort((a: DiceName, b: DiceName) => {
-      if (a.name > b.name) {
-        return 1;
-      } else {
-        return -1;
-      }
-    });
+  return res.data.names.map((x: NameRes) => {
+    return { gameType: x.system, name: x.name };
+  });
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
BCDice v2.04.00 および BCDice-API v0.10.0 で導入された出力順ソートを使用するため、Saipage側ではソートを行わないようにする変更です。

- 注意
現在デフォルトで設定されている https://bcdice.onlinesession.app など、`sort_key` に対応していないバージョンの BCDice-API での並びが非直観的になります。

2020/05/09 00:06 時点での https://bcdice.onlinesession.app/v1/version
```json
{"api":"0.8.0","bcdice":"2.04.00"}
```